### PR TITLE
callback.on_exit needs three arguments to work properly, even if third is not used

### DIFF
--- a/ftplugin/mail_vifm.vim
+++ b/ftplugin/mail_vifm.vim
@@ -24,7 +24,7 @@ function! s:AddMailAttacments()
 	else
 		" Work around handicapped neovim...
 		let callback = { 'listf': l:listf }
-		function! callback.on_exit(id, code)
+		function! callback.on_exit(id, code, event)
 			buffer #
 			silent! bdelete! #
 			call s:HandleRunResults(a:code, self.listf)


### PR DESCRIPTION
The job.on_exit requires a function that takes three arguments, or it will
throw and error and not include the attachments.

As a neovim user, who has long been an ardent vifm user, my only painpoint in
switching to neovim was that this plugin didn't work properly. I discovered
vifm/neovim-vifm and began happily using it in place of this plugin. I then
discovered that when editing vifm files, I lost my ftdetect and syntax. I
offered a pull request to fix this, but of course, having two plugins trying
to keep the syntax highlighting in sync carried potential problems. It
was suggested to me by @xaizek to include both plugins and simply set let
g:loaded_vifm = 'disable' While this initially appeared to work, I had a
separate issue, by setting that to 'disable' g:vifm_exec and g:vifm_exec_args
were not set, so the mail plugin didn't work. I set those by hand and
then discoved the issue for which this pull-request addresses. While this
pull-request will fix the issue for me, it does mean that new adopters, who
might be new to vifm, but already using neovim, will need to know to include
both plugins, disable this one, and set g:vifm_exec by hand.

If I might make a suggestion that would make life easier for all adopters.
Simply combine the plugins. Move (almost) all you the logic currently in this
plugin/vifm.vim to a new folder (i.e. src/vim_vifm.vim), take the logic from
neovim-vifm and put it in the same folder (i.e. src/neovim_vifm.vim). and the
plugin/vifm.vim file would simply contain the following:

```vim
if exists('loaded_vifm')
  finish
endif
let loaded_vifm = 1

if !exists('g:vifm_exec')
  let g:vifm_exec = 'vifm'
endif

if !exists('g:vifm_exec_args')
  let g:vifm_exec_args = ''
endif

if has('nvim')
  source src/neovim_vifm.vim
else
  source src/vim_vifm.vim
endif
```

Now, there will be one plugin to maintain. Maintaining those files will be no
more difficult than they are now and changes to ftdetect, syntax, or any files
in ftplugin will be automatically included for vim and neovim users. I'd be
more than happy to help set this up as a pull request if desired.

Thank you for your time. I hope these suggstions and this pull-request help.