### PR TITLE
Add features from neovim-vifm

### DIFF
--- a/doc/plugin/vifm-plugin.txt
+++ b/doc/plugin/vifm-plugin.txt
@@ -69,6 +69,10 @@ By default it's equal to 'xterm -e'.
 A boolean variable.  When evaluates to true and it's possible to create a
 terminal buffer, it will be used.  Enabled by default inside GUI version.
 
+                                               *g:vifm_embed_split*
+A boolean variable.  When evaluates to true and Vifm is embedded in a
+terminal, it will be run inside a new split.  False by default.
+
 Extension for "vifm" filetype~
 
                                                 *vifm-K*

--- a/doc/plugin/vifm-plugin.txt
+++ b/doc/plugin/vifm-plugin.txt
@@ -81,6 +81,13 @@ A boolean variable.  When evaluates to true and Vifm is embedded in a
 terminal, vifm will change the active directory in vim while navigating.
 False by default.
 
+                                               *g:vifm_replace_netrw*
+A boolean variable.  When enabled, the the |netrw| plugin will be disabled. In
+its place, folders will be opened using vifm.  Defaults to false.
+
+                                               *g:vifm_replace_netrw_cmd*
+A string variable.  The command to use to open folders when
+g:vifm_replace_netrw is enabled.  Defaults to "Vifm".
 
 Extension for "vifm" filetype~
 

--- a/doc/plugin/vifm-plugin.txt
+++ b/doc/plugin/vifm-plugin.txt
@@ -71,7 +71,9 @@ terminal buffer, it will be used.  Enabled by default inside GUI version.
 
                                                *g:vifm_embed_split*
 A boolean variable.  When evaluates to true and Vifm is embedded in a
-terminal, it will be run inside a new split.  False by default.
+terminal, it will be run inside a new split.  This allows commands to support
+|<mods>| and a |<count>| for controlling the orientation and size of the
+split.  False by default.
 
 Extension for "vifm" filetype~
 

--- a/doc/plugin/vifm-plugin.txt
+++ b/doc/plugin/vifm-plugin.txt
@@ -10,6 +10,8 @@ Commands:
 
                                                *vifm-:EditVifm*
   :EditVifm   select a file or files to open in the current buffer.
+                                               *vifm-:Vifm*
+  :Vifm       alias for :EditVifm.
                                                *vifm-:SplitVifm*
   :SplitVifm  split buffer and select a file or files to open.
                                                *vifm-:VsplitVifm*

--- a/doc/plugin/vifm-plugin.txt
+++ b/doc/plugin/vifm-plugin.txt
@@ -68,6 +68,7 @@ By default it's equal to 'xterm -e'.
                                                *g:vifm_embed_term*
 A boolean variable.  When evaluates to true and it's possible to create a
 terminal buffer, it will be used.  Enabled by default inside GUI version.
+Effectively always enabled in neovim.
 
                                                *g:vifm_embed_split*
 A boolean variable.  When evaluates to true and Vifm is embedded in a

--- a/doc/plugin/vifm-plugin.txt
+++ b/doc/plugin/vifm-plugin.txt
@@ -76,6 +76,12 @@ terminal, it will be run inside a new split.  This allows commands to support
 |<mods>| and a |<count>| for controlling the orientation and size of the
 split.  False by default.
 
+                                               *g:vifm_embed_cwd*
+A boolean variable.  When evaluates to true and Vifm is embedded in a
+terminal, vifm will change the active directory in vim while navigating.
+False by default.
+
+
 Extension for "vifm" filetype~
 
                                                 *vifm-K*

--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -37,6 +37,7 @@ endtry
 
 let s:tab_drop_cmd = (s:has_drop ? 'tablast | tab drop' : 'tabedit')
 
+command! -bar -nargs=* -complete=dir Vifm :call s:StartVifm('edit', <f-args>)
 command! -bar -nargs=* -complete=dir EditVifm :call s:StartVifm('edit', <f-args>)
 command! -bar -nargs=* -complete=dir VsplitVifm :call s:StartVifm('vsplit', <f-args>)
 command! -bar -nargs=* -complete=dir SplitVifm :call s:StartVifm('split', <f-args>)

--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -37,20 +37,26 @@ endtry
 
 let s:tab_drop_cmd = (s:has_drop ? 'tablast | tab drop' : 'tabedit')
 
-command! -bar -nargs=* -complete=dir Vifm :call s:StartVifm('edit', <f-args>)
-command! -bar -nargs=* -complete=dir EditVifm :call s:StartVifm('edit', <f-args>)
-command! -bar -nargs=* -complete=dir VsplitVifm :call s:StartVifm('vsplit', <f-args>)
-command! -bar -nargs=* -complete=dir SplitVifm :call s:StartVifm('split', <f-args>)
-command! -bar -nargs=* -complete=dir DiffVifm :call s:StartVifm('vert diffsplit', <f-args>)
-command! -bar -nargs=* -complete=dir TabVifm :call s:StartVifm(s:tab_drop_cmd, <f-args>)
+command! -bar -nargs=* -count -complete=dir Vifm
+			\ :call s:StartVifm('<mods>', <count>, 'edit', <f-args>)
+command! -bar -nargs=* -count -complete=dir EditVifm
+			\ :call s:StartVifm('<mods>', <count>, 'edit', <f-args>)
+command! -bar -nargs=* -count -complete=dir VsplitVifm
+			\ :call s:StartVifm('<mods>', <count>, 'vsplit', <f-args>)
+command! -bar -nargs=* -count -complete=dir SplitVifm
+			\ :call s:StartVifm('<mods>', <count>, 'split', <f-args>)
+command! -bar -nargs=* -count -complete=dir DiffVifm
+			\ :call s:StartVifm('<mods>', <count>, 'vert diffsplit', <f-args>)
+command! -bar -nargs=* -count -complete=dir TabVifm
+			\ :call s:StartVifm('<mods>', <count>, s:tab_drop_cmd, <f-args>)
 
-function! s:StartVifm(editcmd, ...)
+function! s:StartVifm(mods, count, editcmd, ...)
 	echohl WarningMsg | echo 'vifm executable wasn''t found' | echohl None
 endfunction
 
 call vifm#globals#Init()
 
-function! s:StartVifm(editcmd, ...)
+function! s:StartVifm(mods, count, editcmd, ...)
 	if a:0 > 2
 		echohl WarningMsg | echo 'Too many arguments' | echohl None
 		return
@@ -94,8 +100,8 @@ function! s:StartVifm(editcmd, ...)
 				silent! bdelete! #
 				call s:HandleRunResults(a:code, data.listf, data.typef, data.editcmd)
 			endfunction
-			if get(g:, 'vifm_embed_split')
-				new
+			if get(g:, 'vifm_embed_split', 0)
+				exec a:mods . ' ' . (a:count ? a:count : '') . 'new'
 			else
 				enew
 			endif

--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -352,4 +352,21 @@ endfunction
 
 " }}}1
 
+if get(g:, 'vifm_replace_netrw')
+	function! s:HandleBufEnter(fname)
+		if a:fname !=# '' && isdirectory(a:fname)
+			bdelete!
+			let embed_split = get(g:, 'vifm_embed_split', 0)
+			let g:vifm_embed_split = 0
+			exec get(g:, 'vifm_replace_netrw_cmd', 'Vifm') . ' ' . a:fname
+			let g:vifm_embed_split = embed_split
+		endif
+	endfunction
+
+	let g:loaded_netrwPlugin = 'disable'
+	augroup neovimvifm
+		au BufEnter * silent call s:HandleBufEnter(expand('<amatch>'))
+	augroup END
+endif
+
 " vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab :

--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -94,7 +94,11 @@ function! s:StartVifm(editcmd, ...)
 				silent! bdelete! #
 				call s:HandleRunResults(a:code, data.listf, data.typef, data.editcmd)
 			endfunction
-			enew
+			if get(g:, 'vifm_embed_split')
+				new
+			else
+				enew
+			endif
 			let buf = term_start(['/bin/sh', '-c',
 			                     \ g:vifm_exec.' '.g:vifm_exec_args.' '.ldir.' '.rdir
 			                     \.' '.pickargsstr], options)


### PR DESCRIPTION
As discussed in #16, neovim-vifm is now redundant save for a few features. This pull request implements those features:

- Optionally allow opening vifm in a split when embedded in a terminal
- Optionally control the current working directory when embedded in a terminal
- Optionally replace netrw to open folders
- The `:Vifm` command has been added as an alias for `:EditVifm`

Consequential changes:

- All commands now support split modifiers and count, similar to `:[mods] [N]new`
- neovim and `g:vifm_embed_term` code has been merged together so that both vim 8 and neovim can benefit from new embedded terminal features