### PR TITLE
Fix split/netrw window close handling

### DIFF
--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -111,7 +111,7 @@ function! s:StartVifm(mods, count, editcmd, ...)
 				buffer #
 				silent! bdelete! #
 				if data.split
-					close
+					silent! close
 				endif
 				if has('job') && type(data.cwdjob) == v:t_job
 					call job_stop(data.cwdjob)
@@ -127,7 +127,7 @@ function! s:StartVifm(mods, count, editcmd, ...)
 				endif
 				silent! bdelete! #
 				if self.split
-					close
+					silent! close
 				endif
 				if self.cwdjob != 0
 					call jobstop(self.cwdjob)

--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -1,5 +1,3 @@
-" Vim plugin for running vifm from vim.
-
 " Maintainer: Ken Steen <ksteen@users.sourceforge.net>
 " Last Change: 2001 November 29
 
@@ -108,7 +106,11 @@ function! s:StartVifm(mods, count, editcmd, ...)
 
 			function! VifmExitCb(job, code)
 				let data = b:data
-				buffer #
+				if bufnr('%') == bufnr('#') && !data.split
+					enew
+				else
+					buffer #
+				endif
 				silent! bdelete! #
 				if data.split
 					silent! close


### PR DESCRIPTION
There were window closing handling errors introduced with #22.

When opening netrw the folder buffer is deleted just before opening neovim. This prevents vifm from being reopened when exiting, but as an unintended side-effect it closes the current window. This has been fixed.

When exiting from a non-split window, the current buffer is deleted and the window is closed. Now, the window is closed only if vifm was opened in a split, the window is closed.

This fixes #25 