### PR TITLE
Follow links when handling files

### DIFF
--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -252,6 +252,7 @@ function! s:HandleRunResults(exitcode, listf, typef, editcmd)
 
 	let unescaped_firstfile = flist[0]
 	call map(flist, 'fnameescape(v:val)')
+	let firstfile = flist[0]
 
 	if !empty(opentype) && !empty(opentype[0]) &&
 		\ opentype[0] != '"%VIFM_OPEN_TYPE%"'
@@ -261,7 +262,6 @@ function! s:HandleRunResults(exitcode, listf, typef, editcmd)
 	endif
 
 	" Don't split if current window is empty
-	let firstfile = flist[0]
 	if empty(expand('%')) && editcmd =~ '^v\?split$'
 		execute 'edit' fnamemodify(flist[0], ':.')
 		let flist = flist[1:-1]

--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -244,13 +244,14 @@ function! s:HandleRunResults(exitcode, listf, typef, editcmd)
 	let opentype = file_readable(a:typef) ? readfile(a:typef) : []
 	call delete(a:typef)
 
-	call map(flist, 'fnameescape(v:val)')
-
 	" User exits vifm without selecting a file.
 	if empty(flist)
 		echohl WarningMsg | echo 'No file selected' | echohl None
 		return
 	endif
+
+	let unescaped_firstfile = flist[0]
+	call map(flist, 'fnameescape(v:val)')
 
 	if !empty(opentype) && !empty(opentype[0]) &&
 		\ opentype[0] != '"%VIFM_OPEN_TYPE%"'
@@ -282,6 +283,11 @@ function! s:HandleRunResults(exitcode, listf, typef, editcmd)
 	" Go to the first file working around possibility that :drop command is not
 	" evailable, if possible
 	if editcmd == 'edit'
+		" Linked folders must be resolved to successfully call 'buffer'
+		let firstfile = unescaped_firstfile
+		let firstfile = resolve(fnamemodify(firstfile, ':h'))
+					\ .'/'.fnamemodify(firstfile, ':t')
+		let firstfile = fnameescape(firstfile)
 		execute 'buffer' fnamemodify(firstfile, ':.')
 	elseif s:has_drop
 		" Mind that drop replaces arglist, so don't use it with :edit.


### PR DESCRIPTION
Vim uses resolved filenames, and so we must use the resolved file path when using commands like :buffer.

Gets an error when following links in some cases without this change.