### PR TITLE
Allow files with spaces on attachment select

### DIFF
--- a/ftplugin/mail_vifm.vim
+++ b/ftplugin/mail_vifm.vim
@@ -52,7 +52,7 @@ function! s:HandleRunResults(exitcode, listf)
 
 	if filereadable(a:listf) && l:insert_pos != 0
 		for line in readfile(a:listf)
-			call append(l:insert_pos, 'Attach: '.line)
+			call append(l:insert_pos, 'Attach: '.substitute(line, " ", "\\\\ ", "g"))
 			let l:insert_pos += 1
 		endfor
 	endif

--- a/ftplugin/mail_vifm.vim
+++ b/ftplugin/mail_vifm.vim
@@ -52,7 +52,7 @@ function! s:HandleRunResults(exitcode, listf)
 
 	if filereadable(a:listf) && l:insert_pos != 0
 		for line in readfile(a:listf)
-			call append(l:insert_pos, 'Attach: '.substitute(line, " ", "\\\\ ", "g"))
+			call append(l:insert_pos, 'Attach: '.escape(line, " "))
 			let l:insert_pos += 1
 		endfor
 	endif


### PR DESCRIPTION
A file with spaces needs to have backslash escape characters in order to
be properly recognized by mutt.