### PR TITLE
Resolve filename when opening files.

### DIFF
--- a/plugin/vifm.vim
+++ b/plugin/vifm.vim
@@ -1,5 +1,5 @@
 " Maintainer: xaizek <xaizek@posteo.net>
-" Last Change: 2023 July 3
+" Last Change: 2023 August 18
 
 " Author: Ken Steen <ksteen@users.sourceforge.net>
 " Last Change: 2001 November 29
@@ -348,9 +348,10 @@ function! s:HandleRunResults(exitcode, listf, typef, editcmd, bufsnapshot) abort
 	endif
 
 	for file in flist
-		execute editcmd fnamemodify(file, ':.')
+		let file = resolve(fnamemodify(file, ':.'))
+		execute editcmd file
 		if editcmd == 'edit' && len(flist) > 1
-			execute 'argadd' fnamemodify(file, ':.')
+			execute 'argadd' file
 		endif
 	endfor
 


### PR DESCRIPTION
This pull request fixes a bug I discovered on Windows when opening multiple files from a symbolically linked folder. To create such a link I used this Powershell command with Admin privileges:
```powershell
New-Item -ItemType SymbolicLink -Path "C:\Users\Phil\.config\nvim" -Target "C:\Users\Phil\AppData\Local\nvim"
```
When opening a couple files at once from the `~\nvim` directory, vifm.vim was giving me this error:
```
Error detected while processing function 6[13]..<SNR>32_HandleRunResults:
line 86:
E94: No matching buffer for {filename redacted}
```

When this block of code (https://github.com/vifm/vifm.vim/blob/master/plugin/vifm.vim#L366-L371) runs, it starts with forward slashes from vifm, but the resolve function changes them to backslashes, thus not matching the buffer name.

If the comment is to believed, `resolve()` is necessary, so it should also be used when opening the files. That is what this PR changes.